### PR TITLE
Landing page schema

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { getAboutData } from "@/sanity/sanity-utils";
 import React from "react";
-import { urlFor } from "@/lib/image";
+import { urlFor } from "@/sanity/lib/image";
 
 async function AboutPage() {
   const aboutData = await getAboutData();

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,8 +4,7 @@ import React from "react";
 import { urlFor } from "@/lib/image";
 
 async function AboutPage() {
-  const data = await getAboutData();
-  const aboutData = data[0];
+  const aboutData = await getAboutData();
 
   return (
     <section className="p-8 w-full">

--- a/components/LandingPage/Header/Header.tsx
+++ b/components/LandingPage/Header/Header.tsx
@@ -1,7 +1,12 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { LandingPageData } from "@/sanity/sanity-utils";
 
-const Header = () => {
+interface HeaderProps {
+  landingPageData: LandingPageData;
+}
+
+const Header: React.FC<HeaderProps> = ({ landingPageData }) => {
   return (
     <div className="relative w-full">
       <div className="w-full max-h-[40rem] overflow-hidden">
@@ -14,7 +19,7 @@ const Header = () => {
       <div className="absolute inset-0 flex flex-col items-center justify-center w-full">
         <div className="flex flex-col items-center justify-between w-[12rem] md:w-[18rem] xl:w-[24rem] h-full py-2 sm:py-4 md:pb-[4rem] md:pt-[5rem] lg:pb-[5rem] lg:pt-[7rem] xl:pb-[8rem] xl:pt-[10rem]">
           <p className="font-bold text-white text-center sm:text-lg md:text-3xl lg:text-4xl xl:text-5xl">
-            Find your dream home in Arizona
+            {landingPageData.headerTitle}
           </p>
           <div className="flex flex-col gap-2 lg:gap-5 w-[10rem] md:w-[13rem] lg:w-full">
             <Link

--- a/components/LandingPage/Header/Header.tsx
+++ b/components/LandingPage/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { LandingPageData } from "@/sanity/sanity-utils";
+import { urlFor } from "@/sanity/lib/image";
 
 interface HeaderProps {
   landingPageData: LandingPageData;
@@ -11,7 +12,7 @@ const Header: React.FC<HeaderProps> = ({ landingPageData }) => {
     <div className="relative w-full">
       <div className="w-full max-h-[40rem] overflow-hidden">
         <img
-          src="/images/AZsky.webp"
+          src={urlFor(landingPageData.headerImage).url()}
           alt="AZ sky"
           className="w-full h-[18rem] md:h-[25rem] lg:h-[30rem] xl:h-[40rem]"
         />

--- a/components/LandingPage/LandingPage.tsx
+++ b/components/LandingPage/LandingPage.tsx
@@ -20,11 +20,10 @@ export async function getServerSideProps() {
 }
 
 const LandingPage: React.FC<LandingPageProps> = ({ landingPageData }) => {
-  console.log("landing page data", landingPageData);
   return (
     <>
       <Header landingPageData={landingPageData} />
-      <MissionStatementSection />
+      <MissionStatementSection landingPageData={landingPageData} />
       <ReviewsSection />
       <BlogSection />
     </>

--- a/components/LandingPage/LandingPage.tsx
+++ b/components/LandingPage/LandingPage.tsx
@@ -2,11 +2,28 @@ import Header from "./Header";
 import ReviewsSection from "./ReviewsSection";
 import BlogSection from "./BlogSection";
 import MissionStatementSection from "./MissionStatementSection";
+import { getLandingPageData } from "@/sanity/sanity-utils";
+import { LandingPageData } from "@/sanity/sanity-utils";
 
-const LandingPage = async () => {
+interface LandingPageProps {
+  landingPageData: LandingPageData;
+}
+
+export async function getServerSideProps() {
+  const landingPageData = await getLandingPageData();
+
+  return {
+    props: {
+      landingPageData,
+    },
+  };
+}
+
+const LandingPage: React.FC<LandingPageProps> = ({ landingPageData }) => {
+  console.log("landing page data", landingPageData);
   return (
     <>
-      <Header />
+      <Header landingPageData={landingPageData} />
       <MissionStatementSection />
       <ReviewsSection />
       <BlogSection />

--- a/components/LandingPage/MissionStatementSection/Components/MissionHeader.tsx
+++ b/components/LandingPage/MissionStatementSection/Components/MissionHeader.tsx
@@ -1,11 +1,16 @@
 import Pfp from "@/components/AssetComponents/Pfp";
 import React from "react";
+import { LandingPageData } from "@/sanity/sanity-utils";
 
-const MissionHeader = () => {
+interface MissionHeaderProps {
+  landingPageData: LandingPageData;
+}
+
+const MissionHeader: React.FC<MissionHeaderProps> = ({ landingPageData }) => {
   return (
     <div className="flex flex-col md:flex-col-reverse gap-4">
       <h3 className="font-bold text-[40px] leading-none text-blue">
-        “Welcome to Your New Home Sweet Home”
+        {landingPageData.aboutTitle}
       </h3>
       <div className="flex w-full gap-[1rem] justify-center items-center md:items-start md:justify-start md:flex-col-reverse">
         <div>

--- a/components/LandingPage/MissionStatementSection/MissionStatementSection.tsx
+++ b/components/LandingPage/MissionStatementSection/MissionStatementSection.tsx
@@ -1,25 +1,28 @@
 /* eslint-disable @next/next/no-img-element */
 import MissionHeader from "./Components/MissionHeader";
 import ReadMoreButton from "./Components/ReadMoreButton";
+import { LandingPageData } from "@/sanity/sanity-utils";
+import { urlFor } from "@/sanity/lib/image";
 
-const MissionStatementSection = async () => {
+interface MissionStatementSectionProps {
+  landingPageData: LandingPageData;
+}
+
+const MissionStatementSection: React.FC<MissionStatementSectionProps> = ({
+  landingPageData,
+}) => {
   return (
     <section className="md:flex gap-4 w-full items-center p-4 md:min-h-[40rem]">
       <div className="hidden md:block w-1/2 h-full">
         <img
           className="object-cover"
-          src="/images/assets/AZ-RE-1.png"
+          src={urlFor(landingPageData.aboutImage).url()}
           alt="Mission Image"
         />
       </div>
       <div className="w-full md:w-[40%] flex flex-col justify-center items-center md:items-start gap-6">
-        <MissionHeader />
-        <p className="text-start">
-          OUR MISSION IS TO FIERCELY PROTECT YOUR REAL ESTATE GOALS WITH EXPERT
-          GUIDANCE, INTEGRITY, AND A RELENTLESS COMMITMENT TO YOUR
-          SUCCESS—MAKING EVERY STEP IN ARIZONA REAL ESTATE SEAMLESS, SECURE, AND
-          EMPOWERING.
-        </p>
+        <MissionHeader landingPageData={landingPageData} />
+        <p className="text-start">{landingPageData.aboutDescription}</p>
         <div className="w-full">
           <ReadMoreButton />
         </div>

--- a/components/LandingPage/ReviewsSection/components/ReviewsTitle.tsx
+++ b/components/LandingPage/ReviewsSection/components/ReviewsTitle.tsx
@@ -3,7 +3,7 @@ import React from "react";
 const ReviewsTitle = () => {
   return (
     <div className="text-white p-4 flex align-center flex-col justify-center md:text-center">
-      <h2 className="text-2xl font-semibold">Reviews</h2>
+      <h2 className="text-2xl font-semibold">Testimonials</h2>
       <div className="w-[6rem] h-0.5 bg-white mb-4 md:mx-auto" />
       <p className="font-bold text-[2rem] leading-none">
         Experience the perfect blend of style and functionality

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -1,6 +1,6 @@
 import { client } from "@/sanity/lib/client";
 
-interface SanityImage {
+export interface SanityImage {
   _type: "image";
   asset: {
     _type: "reference";
@@ -94,7 +94,7 @@ export async function getAboutData(): Promise<AboutMe> {
     name,
     description,
     "imageUrl": image.asset->url
-  }`;
+  }[0]`;
   const about = await client.fetch(ABOUT_QUERY, {}, options);
   return about;
 }
@@ -116,7 +116,7 @@ export async function getLandingPageData(): Promise<LandingPageData> {
     aboutImage,
     aboutTitle,
     aboutDescription
-  }`;
+  }[0]`;
   const landingPageData = await client.fetch(LANDING_QUERY, {}, options);
   return landingPageData;
 }

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -111,9 +111,9 @@ export async function getLandingPageData(): Promise<LandingPageData> {
   const options = { next: { revalidate: 30 } };
 
   const LANDING_QUERY = `*[_type == "landingPage"]{
-    headerImage,
+    "headerImage": headerImage.asset->url,
     headerTitle,
-    aboutImage,
+    "aboutImage": aboutImage.asset->url,
     aboutTitle,
     aboutDescription
   }[0]`;

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -80,20 +80,43 @@ export async function getBlogs(): Promise<Blog[]> {
   const blogs = await client.fetch(BLOG_QUERY, {}, options);
   return blogs;
 }
+
 export interface AboutMe {
   name: string;
   imageUrl: SanityImage;
   description: string;
 }
 
-export async function getAboutData(): Promise<AboutMe[]> {
+export async function getAboutData(): Promise<AboutMe> {
   const options = { next: { revalidate: 30 } };
 
-  const BLOG_QUERY = `*[_type == "aboutMe"]{
+  const ABOUT_QUERY = `*[_type == "aboutMe"]{
     name,
     description,
     "imageUrl": image.asset->url
   }`;
-  const blogs = await client.fetch(BLOG_QUERY, {}, options);
-  return blogs;
+  const about = await client.fetch(ABOUT_QUERY, {}, options);
+  return about;
+}
+
+export interface LandingPageData {
+  headerImage: SanityImage;
+  headerTitle: string;
+  aboutImage: SanityImage;
+  aboutTitle: string;
+  aboutDescription: string;
+}
+
+export async function getLandingPageData(): Promise<LandingPageData> {
+  const options = { next: { revalidate: 30 } };
+
+  const LANDING_QUERY = `*[_type == "landingPage"]{
+    headerImage,
+    headerTitle,
+    aboutImage,
+    aboutTitle,
+    aboutDescription
+  }`;
+  const landingPageData = await client.fetch(LANDING_QUERY, {}, options);
+  return landingPageData;
 }

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -2,7 +2,8 @@ import { type SchemaTypeDefinition } from "sanity";
 import { blogType } from "./blogType";
 import { reviewType } from "./reviewType";
 import { aboutMeType } from "./aboutMeType";
+import { landingPageType } from "./landingPageType";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [blogType, reviewType, aboutMeType],
+  types: [blogType, reviewType, aboutMeType, landingPageType],
 };

--- a/sanity/schemaTypes/landingPageType.ts
+++ b/sanity/schemaTypes/landingPageType.ts
@@ -30,10 +30,5 @@ export const landingPageType = defineType({
       type: "text",
       validation: (Rule) => Rule.required(),
     }),
-    defineField({
-      name: "eventsImage",
-      type: "image",
-      validation: (Rule) => Rule.required(),
-    }),
   ],
 });

--- a/sanity/schemaTypes/landingPageType.ts
+++ b/sanity/schemaTypes/landingPageType.ts
@@ -1,0 +1,39 @@
+import { defineField, defineType } from "sanity";
+
+export const landingPageType = defineType({
+  name: "landingPage",
+  title: "Landing Page",
+  type: "document",
+  fields: [
+    defineField({
+      name: "headerImage",
+      type: "image",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "headerTitle",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "aboutImage",
+      type: "image",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "aboutTitle",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "aboutDescription",
+      type: "text",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "eventsImage",
+      type: "image",
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+});


### PR DESCRIPTION
This pull request includes significant updates to the landing page components and the Sanity data fetching logic. The changes primarily focus on integrating data from Sanity and updating the components to use this data dynamically.

Updates to landing page components:

* [`components/LandingPage/Header/Header.tsx`](diffhunk://#diff-2e64a0a06faa7c01f2b49372de93b326f40c37b2485178d16a86b155da6532eeR3-R23): Added `HeaderProps` interface and updated the `Header` component to use `landingPageData` for the header image and title.
* [`components/LandingPage/MissionStatementSection/MissionStatementSection.tsx`](diffhunk://#diff-e3479d056aaf3f8399b3564a6eb5e8a738e21badabbe0bcefefd577868448e7fR4-R25): Added `MissionStatementSectionProps` interface and updated the `MissionStatementSection` component to use `landingPageData` for the mission image and description.
* [`components/LandingPage/MissionStatementSection/Components/MissionHeader.tsx`](diffhunk://#diff-9aa84f798859e609e226852371493cb98b97c3c8efd116063cab4697bc7fef98R3-R13): Added `MissionHeaderProps` interface and updated the `MissionHeader` component to use `landingPageData` for the mission header title.
* [`components/LandingPage/LandingPage.tsx`](diffhunk://#diff-857dc32e1e0126094b7f1caf52556fc976957ed4363472b00c2a044785e5ef8cR5-R26): Updated `LandingPage` component to fetch `landingPageData` server-side and pass it to child components.

Sanity data fetching and schema updates:

* [`sanity/sanity-utils.ts`](diffhunk://#diff-364db0e871160cddd0b6091416b5405f34b3dff3aad9d84389076625f2671c88L3-R3): Added new `LandingPageData` interface and `getLandingPageData` function to fetch landing page data from Sanity. Updated `getAboutData` function to return a single `AboutMe` object instead of an array. [[1]](diffhunk://#diff-364db0e871160cddd0b6091416b5405f34b3dff3aad9d84389076625f2671c88L3-R3) [[2]](diffhunk://#diff-364db0e871160cddd0b6091416b5405f34b3dff3aad9d84389076625f2671c88R83-R121)
* [`sanity/schemaTypes/index.ts`](diffhunk://#diff-ddcae68857ea31eeace9e5f1a3219f1852d63428200105492d09f264e6526c19R5-R8): Added `landingPageType` to the schema types.
* [`sanity/schemaTypes/landingPageType.ts`](diffhunk://#diff-70eba63f43927c1df6e9e4df82d6947a6b50a96cf625e654a073683744f16d01R1-R34): Created a new schema type for the landing page with fields for header image, header title, about image, about title, and about description.